### PR TITLE
Required gulp zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 const {series, parallel, watch, src, dest} = require('gulp');
 const pump = require('pump');
+const zip = require('gulp-zip');
 
 // gulp plugins and utils
 const livereload = require('gulp-livereload');


### PR DESCRIPTION
Fixed error "ReferenceError: zip is not defined" when trying to compress.